### PR TITLE
DEV-10926: moved new period variable out of components

### DIFF
--- a/.changeset/smooth-pens-invite.md
+++ b/.changeset/smooth-pens-invite.md
@@ -1,0 +1,5 @@
+---
+"custom-block-kit": patch
+---
+
+Moved new variable for add/sub date calc out of children as it was causing variable unique conflicts

--- a/blocks/date-calc/date-calc.ts
+++ b/blocks/date-calc/date-calc.ts
@@ -99,44 +99,6 @@ export class DateCalc {
                 options: "getDateVariables",
               },
             },
-            {
-              ref: "datecalc_save_group",
-              component: "Group",
-              componentProps: {
-                label: "Save resulting new datetime variable as",
-              },
-              children: [
-                {
-                  ref: "new_datetime_variable",
-                  component: "TextInput",
-                  componentProps: {
-                    label: "Name of the new DATE variable",
-                    placeholder: "Variable name",
-                    format: "format_date_add"
-                  },
-                  validators: [
-                    {
-                      method: "isVariableUnique",
-                      message: "This variable already exists!",
-                    },
-                    {
-                      method: "max",
-                      value: "50",
-                      message: "This must be less than 50 characters",
-                    },
-                  ],
-                },
-                {
-                  ref: "format_date_add",
-                  component: "SelectInput",
-                  componentProps: {
-                    label: "Format Date as",
-                    placeholder: "YYYY/MM/DD",
-                    options: dateOptions,
-                  },
-                },
-              ],
-            },
           ],
         },
         {
@@ -185,50 +147,51 @@ export class DateCalc {
                 options: "getDateVariables",
               },
             },
+          ],
+        },
+        {
+          ref: "datecalc_save_add_sub",
+          component: "Group",
+          componentProps: {
+            label: "Save resulting new datetime variable as",
+          },
+          showIf: "fn_selector == 'subtract' || fn_selector == 'add'",
+          children: [
             {
-              ref: "datecalc_save_group",
-              component: "Group",
+              ref: "new_datetime_variable",
+              component: "TextInput",
               componentProps: {
-                label: "Save resulting new datetime variable as",
+                label: "Name of the new DATE variable",
+                placeholder: "Variable name",
+                format: "format_date",
               },
-              children: [
+              validators: [
                 {
-                  ref: "new_datetime_variable",
-                  component: "TextInput",
-                  componentProps: {
-                    label: "Name of the new DATE variable",
-                    placeholder: "Variable name",
-                    format: "format_date_sub"
-                  },
-                  validators: [
-                    {
-                      method: "isVariableUnique",
-                      message: "This variable already exists!",
-                    },
-                    {
-                      method: "max",
-                      value: "50",
-                      message: "This must be less than 50 characters",
-                    },
-                    {
-                        method: "required",
-                        message: "Must enter a variable name",
-                    }
-                  ],
-                  output: {
-                    as: "DATE",
-                  },
+                  method: "isVariableUnique",
+                  message: "This variable already exists!",
                 },
                 {
-                  ref: "format_date_sub",
-                  component: "SelectInput",
-                  componentProps: {
-                    label: "Format Date as",
-                    placeholder: "YYYY/MM/DD",
-                    options: dateOptions,
-                  },
+                  method: "max",
+                  value: "50",
+                  message: "This must be less than 50 characters",
+                },
+                {
+                  method: "required",
+                  message: "Must enter a variable name",
                 },
               ],
+              output: {
+                as: "DATE",
+              },
+            },
+            {
+              ref: "format_date",
+              component: "SelectInput",
+              componentProps: {
+                label: "Format Date as",
+                placeholder: "YYYY/MM/DD",
+                options: dateOptions,
+              },
             },
           ],
         },
@@ -352,7 +315,9 @@ export class DateCalc {
           const dateB = cbk.getVariable(cbk.getElementValue("diff_date_b"));
           const timez = moment(dateA).parseZone().utcOffset();
           const diffUnit = cbk.getElementValue("diff_time_unit");
-          const difference = moment(dateB).utcOffset(timez).diff(moment(dateA).utcOffset(timez), diffUnit);
+          const difference = moment(dateB)
+            .utcOffset(timez)
+            .diff(moment(dateA).utcOffset(timez), diffUnit);
           cbk.setOutput(newDiffVarName, difference);
           break;
       }

--- a/dist/index.js
+++ b/dist/index.js
@@ -163,44 +163,6 @@ var DateCalc = class {
                   placeholder: "Select date variable",
                   options: "getDateVariables"
                 }
-              },
-              {
-                ref: "datecalc_save_group",
-                component: "Group",
-                componentProps: {
-                  label: "Save resulting new datetime variable as"
-                },
-                children: [
-                  {
-                    ref: "new_datetime_variable",
-                    component: "TextInput",
-                    componentProps: {
-                      label: "Name of the new DATE variable",
-                      placeholder: "Variable name",
-                      format: "format_date_add"
-                    },
-                    validators: [
-                      {
-                        method: "isVariableUnique",
-                        message: "This variable already exists!"
-                      },
-                      {
-                        method: "max",
-                        value: "50",
-                        message: "This must be less than 50 characters"
-                      }
-                    ]
-                  },
-                  {
-                    ref: "format_date_add",
-                    component: "SelectInput",
-                    componentProps: {
-                      label: "Format Date as",
-                      placeholder: "YYYY/MM/DD",
-                      options: dateOptions
-                    }
-                  }
-                ]
               }
             ]
           },
@@ -249,51 +211,52 @@ var DateCalc = class {
                   placeholder: "Select date variable",
                   options: "getDateVariables"
                 }
-              },
+              }
+            ]
+          },
+          {
+            ref: "datecalc_save_add_sub",
+            component: "Group",
+            componentProps: {
+              label: "Save resulting new datetime variable as"
+            },
+            showIf: "fn_selector == 'subtract' || fn_selector == 'add'",
+            children: [
               {
-                ref: "datecalc_save_group",
-                component: "Group",
+                ref: "new_datetime_variable",
+                component: "TextInput",
                 componentProps: {
-                  label: "Save resulting new datetime variable as"
+                  label: "Name of the new DATE variable",
+                  placeholder: "Variable name",
+                  format: "format_date"
                 },
-                children: [
+                validators: [
                   {
-                    ref: "new_datetime_variable",
-                    component: "TextInput",
-                    componentProps: {
-                      label: "Name of the new DATE variable",
-                      placeholder: "Variable name",
-                      format: "format_date_sub"
-                    },
-                    validators: [
-                      {
-                        method: "isVariableUnique",
-                        message: "This variable already exists!"
-                      },
-                      {
-                        method: "max",
-                        value: "50",
-                        message: "This must be less than 50 characters"
-                      },
-                      {
-                        method: "required",
-                        message: "Must enter a variable name"
-                      }
-                    ],
-                    output: {
-                      as: "DATE"
-                    }
+                    method: "isVariableUnique",
+                    message: "This variable already exists!"
                   },
                   {
-                    ref: "format_date_sub",
-                    component: "SelectInput",
-                    componentProps: {
-                      label: "Format Date as",
-                      placeholder: "YYYY/MM/DD",
-                      options: dateOptions
-                    }
+                    method: "max",
+                    value: "50",
+                    message: "This must be less than 50 characters"
+                  },
+                  {
+                    method: "required",
+                    message: "Must enter a variable name"
                   }
-                ]
+                ],
+                output: {
+                  as: "DATE"
+                }
+              },
+              {
+                ref: "format_date",
+                component: "SelectInput",
+                componentProps: {
+                  label: "Format Date as",
+                  placeholder: "YYYY/MM/DD",
+                  options: dateOptions
+                }
               }
             ]
           },
@@ -358,7 +321,7 @@ var DateCalc = class {
                     ]
                   },
                   {
-                    ref: "new_diff_variable",
+                    ref: "new_diff_variable_sub",
                     component: "TextInput",
                     componentProps: {
                       label: "Name of the new DATE variable",

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -136,44 +136,6 @@ var DateCalc = class {
                   placeholder: "Select date variable",
                   options: "getDateVariables"
                 }
-              },
-              {
-                ref: "datecalc_save_group",
-                component: "Group",
-                componentProps: {
-                  label: "Save resulting new datetime variable as"
-                },
-                children: [
-                  {
-                    ref: "new_datetime_variable",
-                    component: "TextInput",
-                    componentProps: {
-                      label: "Name of the new DATE variable",
-                      placeholder: "Variable name",
-                      format: "format_date_add"
-                    },
-                    validators: [
-                      {
-                        method: "isVariableUnique",
-                        message: "This variable already exists!"
-                      },
-                      {
-                        method: "max",
-                        value: "50",
-                        message: "This must be less than 50 characters"
-                      }
-                    ]
-                  },
-                  {
-                    ref: "format_date_add",
-                    component: "SelectInput",
-                    componentProps: {
-                      label: "Format Date as",
-                      placeholder: "YYYY/MM/DD",
-                      options: dateOptions
-                    }
-                  }
-                ]
               }
             ]
           },
@@ -222,51 +184,52 @@ var DateCalc = class {
                   placeholder: "Select date variable",
                   options: "getDateVariables"
                 }
-              },
+              }
+            ]
+          },
+          {
+            ref: "datecalc_save_add_sub",
+            component: "Group",
+            componentProps: {
+              label: "Save resulting new datetime variable as"
+            },
+            showIf: "fn_selector == 'subtract' || fn_selector == 'add'",
+            children: [
               {
-                ref: "datecalc_save_group",
-                component: "Group",
+                ref: "new_datetime_variable",
+                component: "TextInput",
                 componentProps: {
-                  label: "Save resulting new datetime variable as"
+                  label: "Name of the new DATE variable",
+                  placeholder: "Variable name",
+                  format: "format_date"
                 },
-                children: [
+                validators: [
                   {
-                    ref: "new_datetime_variable",
-                    component: "TextInput",
-                    componentProps: {
-                      label: "Name of the new DATE variable",
-                      placeholder: "Variable name",
-                      format: "format_date_sub"
-                    },
-                    validators: [
-                      {
-                        method: "isVariableUnique",
-                        message: "This variable already exists!"
-                      },
-                      {
-                        method: "max",
-                        value: "50",
-                        message: "This must be less than 50 characters"
-                      },
-                      {
-                        method: "required",
-                        message: "Must enter a variable name"
-                      }
-                    ],
-                    output: {
-                      as: "DATE"
-                    }
+                    method: "isVariableUnique",
+                    message: "This variable already exists!"
                   },
                   {
-                    ref: "format_date_sub",
-                    component: "SelectInput",
-                    componentProps: {
-                      label: "Format Date as",
-                      placeholder: "YYYY/MM/DD",
-                      options: dateOptions
-                    }
+                    method: "max",
+                    value: "50",
+                    message: "This must be less than 50 characters"
+                  },
+                  {
+                    method: "required",
+                    message: "Must enter a variable name"
                   }
-                ]
+                ],
+                output: {
+                  as: "DATE"
+                }
+              },
+              {
+                ref: "format_date",
+                component: "SelectInput",
+                componentProps: {
+                  label: "Format Date as",
+                  placeholder: "YYYY/MM/DD",
+                  options: dateOptions
+                }
               }
             ]
           },
@@ -331,7 +294,7 @@ var DateCalc = class {
                     ]
                   },
                   {
-                    ref: "new_diff_variable",
+                    ref: "new_diff_variable_sub",
                     component: "TextInput",
                     componentProps: {
                       label: "Name of the new DATE variable",


### PR DESCRIPTION
Key changes are I moved the new variable declaration for the 'add' and 'sub' groups out of those components, into it's own component. Reason for this is that if we have them in their individual components it was causing a variable clash in the go-service. This will need to be investigated later if we ever require double outputs. 