### PR TITLE
DEV-12111-add deselector in option field

### DIFF
--- a/.changeset/cool-horses-help.md
+++ b/.changeset/cool-horses-help.md
@@ -1,0 +1,5 @@
+---
+"custom-block-kit": patch
+---
+
+add deselector for ticketing fields

--- a/base/base.ts
+++ b/base/base.ts
@@ -94,6 +94,7 @@ type CustomOptionString =
   | "getFileVariables"
   | "getFormattableListVariables"
   | "getTextVariables"
+  | "getTicketingEmailSubjectVariables"
   | "getRadioVariables"
   | "getRadioOptions"
   | "getOnlyDocVariables";
@@ -112,6 +113,7 @@ export interface ComponentProps {
   inputComponent?: EditorField;
   keyValueComponents?: (cbk: FrontendCBK) => Promise<KeyValueOptionProp[]>;
   isSearchable?: boolean;
+  allowUnselect?: boolean;
   format?: string;
   whenChanged?: (cbk: FrontendCBK, value?: any) => void | string;
   variableAutoComplete?: boolean;

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -98,7 +98,7 @@ interface BackendCBK {
     hasInput(name: string): boolean;
     overwriteInput(name: string, value: any): void;
 }
-type CustomOptionString = "getDateVariables" | "getExistingVariables" | "getFileVariables" | "getFormattableListVariables" | "getTextVariables" | "getRadioVariables" | "getRadioOptions" | "getOnlyDocVariables";
+type CustomOptionString = "getDateVariables" | "getExistingVariables" | "getFileVariables" | "getFormattableListVariables" | "getTextVariables" | "getTicketingEmailSubjectVariables" | "getRadioVariables" | "getRadioOptions" | "getOnlyDocVariables";
 interface ComponentProps {
     label?: string;
     icon?: string;
@@ -107,6 +107,7 @@ interface ComponentProps {
     inputComponent?: EditorField;
     keyValueComponents?: (cbk: FrontendCBK) => Promise<KeyValueOptionProp[]>;
     isSearchable?: boolean;
+    allowUnselect?: boolean;
     format?: string;
     whenChanged?: (cbk: FrontendCBK, value?: any) => void | string;
     variableAutoComplete?: boolean;

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -3061,6 +3061,7 @@ var Ticket = class {
                   label: "Select board*",
                   placeholder: "Select a board",
                   isSearchable: true,
+                  allowUnselect: true,
                   options: (cbk) => __async(this, null, function* () {
                     const response = yield cbk.api.get("/ticketing/boards");
                     return (response == null ? void 0 : response.result) ? response.result.map(
@@ -3098,14 +3099,20 @@ var Ticket = class {
                 componentProps: {
                   label: "Function",
                   placeholder: "Select a function",
+                  allowUnselect: true,
                   options: [
                     {
                       label: "Create new ticket",
-                      value: "create_new_ticket",
-                      defaultChecked: true
+                      value: "create_new_ticket"
                     }
                   ]
-                }
+                },
+                validators: [
+                  {
+                    method: "required",
+                    message: "Please select a function"
+                  }
+                ]
               },
               {
                 ref: "ticket_layout_id",
@@ -3114,6 +3121,7 @@ var Ticket = class {
                   label: "Ticket layout",
                   placeholder: "Select ticket layout",
                   isSearchable: true,
+                  allowUnselect: true,
                   options: (cbk) => __async(this, null, function* () {
                     var _a, _b;
                     const response = yield cbk.api.get(
@@ -3129,7 +3137,13 @@ var Ticket = class {
                   whenChanged: (cbk) => {
                     cbk.setElementValue("ticketing_layout_field_selector", "");
                   }
-                }
+                },
+                validators: [
+                  {
+                    method: "required",
+                    message: "Please select a ticket layout"
+                  }
+                ]
               }
             ]
           },
@@ -3166,16 +3180,19 @@ var Ticket = class {
                       DATE_TIME: ["DATE"]
                     };
                     return response ? (_b = (_a = response == null ? void 0 : response.result) == null ? void 0 : _a.fields) == null ? void 0 : _b.map((v) => {
+                      var _a2;
                       const mapping = ticketingWorkflowVarMapping[v.fieldType];
-                      const filteredVars = allWorkflowVars.filter(
-                        (v2) => mapping ? mapping.includes(v2.type) : true
+                      let filteredVars = allWorkflowVars.filter(
+                        (workflowVar) => !mapping || (mapping == null ? void 0 : mapping.includes(workflowVar.type)) || // for single select field, we allow COMP variable
+                        v.fieldType === "SEL" && /^COMP\d+/.test(workflowVar.label)
                       );
                       return {
                         left: {
                           ref: "value",
                           component: "SelectInput",
                           componentProps: {
-                            options: filteredVars
+                            options: filteredVars,
+                            allowUnselect: !((_a2 = v.metadata) == null ? void 0 : _a2.isReadonly)
                           }
                         },
                         right: {
@@ -3210,7 +3227,8 @@ var Ticket = class {
                 componentProps: {
                   label: "Add subject into a ticket*",
                   placeholder: "--None--",
-                  options: "getTextVariables"
+                  options: "getTicketingEmailSubjectVariables",
+                  allowUnselect: true
                 },
                 validators: [
                   {
@@ -3236,7 +3254,8 @@ var Ticket = class {
                 componentProps: {
                   label: "Add messages into ticket's conversation thread",
                   placeholder: "--None--",
-                  options: "getTextVariables"
+                  options: "getTextVariables",
+                  allowUnselect: true
                 }
               }
             ]
@@ -3309,12 +3328,16 @@ var Ticket = class {
             const subjectVariable = cbk.getElementValue("subject_variable");
             const messageVariable = cbk.getElementValue("message_variable");
             const subject = cbk.getVariable(subjectVariable);
-            const message = cbk.getVariable(messageVariable);
-            const attachments = JSON.parse((_a = cbk.getElementValue("attachments")) != null ? _a : "[]");
+            const message = (messageVariable == null ? void 0 : messageVariable.length) ? cbk.getVariable(messageVariable) : "";
+            const attachments = JSON.parse(
+              (_a = cbk.getElementValue("attachments")) != null ? _a : "[]"
+            );
             const checkbox = yield cbk.apiClient.checkbox();
             const ticketingMessageService = checkbox.ticketingMessageService;
             const ticketingTicketService = checkbox.ticketingTicketService;
-            const keyValueMappings = JSON.parse((_b = cbk.getElementValue("ticketing_layout_field_selector")) != null ? _b : "[]");
+            const keyValueMappings = JSON.parse(
+              (_b = cbk.getElementValue("ticketing_layout_field_selector")) != null ? _b : "[]"
+            );
             const ticketFieldsRaw = {};
             for (const mapping of keyValueMappings) {
               if (mapping.id && mapping.value) {


### PR DESCRIPTION
subject field should disallow PARA, allow COMP [DEV-12108](https://checkboxai.atlassian.net/browse/DEV-12108)

single select field should allow COMP [DEV-12109](https://checkboxai.atlassian.net/browse/DEV-12109)

should have deselector ‘--None--’ for all fields except requestor [DEV-12111](https://checkboxai.atlassian.net/browse/DEV-12111)

Changes:
- Added getTicketingEmailSubjectVariables that fetch only TXT and COMP
- Added '--None--' to all selectors
- Special condition to exclude '--None--' for requestor field in keyvaluemapping
- validators for field when '--None--' is selected
- for single select field, allow COMP variable