### PR TITLE
Dev-12111 DEV-12118 cbk ticketing block changes

### DIFF
--- a/.changeset/moody-doors-check.md
+++ b/.changeset/moody-doors-check.md
@@ -1,0 +1,5 @@
+---
+"custom-block-kit": patch
+---
+
+add showPageRef for text field

--- a/base/base.ts
+++ b/base/base.ts
@@ -119,6 +119,7 @@ export interface ComponentProps {
   variableAutoComplete?: boolean;
   includeEmptyErrorPlaceholder?: boolean;
   optionsRef?: string;
+  showPageRef?: boolean;
 }
 
 export interface KeyValueOptionProp {

--- a/blocks/ticket/ticket.ts
+++ b/blocks/ticket/ticket.ts
@@ -274,6 +274,7 @@ export class Ticket {
           component: "TextInput",
           componentProps: {
             label: "Return ID",
+            showPageRef: true,
           },
           validators: [
             {

--- a/blocks/ticket/ticket.ts
+++ b/blocks/ticket/ticket.ts
@@ -179,7 +179,7 @@ export class Ticket {
                             component: "SelectInput",
                             componentProps: {
                               options: filteredVars,
-                              allowUnselect: !v.metadata?.isReadonly,
+                              allowUnselect: !v.metadata?.isReadOnly,
                             },
                           },
                           right: {

--- a/blocks/ticket/ticket.ts
+++ b/blocks/ticket/ticket.ts
@@ -36,7 +36,6 @@ export class Ticket {
                 label: "Select board*",
                 placeholder: "Select a board",
                 isSearchable: true,
-                allowUnselect: true,
                 options: async (cbk) => {
                   const response = await cbk.api.get<any>("/ticketing/boards");
                   return response?.result
@@ -76,7 +75,6 @@ export class Ticket {
               componentProps: {
                 label: "Function",
                 placeholder: "Select a function",
-                allowUnselect: true,
                 options: [
                   {
                     label: "Create new ticket",
@@ -98,7 +96,6 @@ export class Ticket {
                 label: "Ticket layout",
                 placeholder: "Select ticket layout",
                 isSearchable: true,
-                allowUnselect: true,
                 options: async (cbk) => {
                   const response = await cbk.api.get<any>(
                     "/ticketing/ticket-layouts?offset=0&limit=100000&status=live"
@@ -216,7 +213,6 @@ export class Ticket {
                 label: "Add subject into a ticket*",
                 placeholder: "--None--",
                 options: "getTicketingEmailSubjectVariables",
-                allowUnselect: true,
               },
               validators: [
                 {
@@ -243,7 +239,6 @@ export class Ticket {
                 label: "Add messages into ticket's conversation thread",
                 placeholder: "--None--",
                 options: "getTextVariables",
-                allowUnselect: true,
               },
             },
           ],

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -113,6 +113,7 @@ interface ComponentProps {
     variableAutoComplete?: boolean;
     includeEmptyErrorPlaceholder?: boolean;
     optionsRef?: string;
+    showPageRef?: boolean;
 }
 interface KeyValueOptionProp {
     left: EditorField;

--- a/dist/index.js
+++ b/dist/index.js
@@ -3314,7 +3314,8 @@ var Ticket = class {
             ref: "ticket_return_id",
             component: "TextInput",
             componentProps: {
-              label: "Return ID"
+              label: "Return ID",
+              showPageRef: true
             },
             validators: [
               {

--- a/dist/index.js
+++ b/dist/index.js
@@ -3221,7 +3221,7 @@ var Ticket = class {
                           component: "SelectInput",
                           componentProps: {
                             options: filteredVars,
-                            allowUnselect: !((_a2 = v.metadata) == null ? void 0 : _a2.isReadonly)
+                            allowUnselect: !((_a2 = v.metadata) == null ? void 0 : _a2.isReadOnly)
                           }
                         },
                         right: {

--- a/dist/index.js
+++ b/dist/index.js
@@ -3090,7 +3090,6 @@ var Ticket = class {
                   label: "Select board*",
                   placeholder: "Select a board",
                   isSearchable: true,
-                  allowUnselect: true,
                   options: (cbk) => __async(this, null, function* () {
                     const response = yield cbk.api.get("/ticketing/boards");
                     return (response == null ? void 0 : response.result) ? response.result.map(
@@ -3128,7 +3127,6 @@ var Ticket = class {
                 componentProps: {
                   label: "Function",
                   placeholder: "Select a function",
-                  allowUnselect: true,
                   options: [
                     {
                       label: "Create new ticket",
@@ -3150,7 +3148,6 @@ var Ticket = class {
                   label: "Ticket layout",
                   placeholder: "Select ticket layout",
                   isSearchable: true,
-                  allowUnselect: true,
                   options: (cbk) => __async(this, null, function* () {
                     var _a, _b;
                     const response = yield cbk.api.get(
@@ -3256,8 +3253,7 @@ var Ticket = class {
                 componentProps: {
                   label: "Add subject into a ticket*",
                   placeholder: "--None--",
-                  options: "getTicketingEmailSubjectVariables",
-                  allowUnselect: true
+                  options: "getTicketingEmailSubjectVariables"
                 },
                 validators: [
                   {
@@ -3283,8 +3279,7 @@ var Ticket = class {
                 componentProps: {
                   label: "Add messages into ticket's conversation thread",
                   placeholder: "--None--",
-                  options: "getTextVariables",
-                  allowUnselect: true
+                  options: "getTextVariables"
                 }
               }
             ]

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -3192,7 +3192,7 @@ var Ticket = class {
                           component: "SelectInput",
                           componentProps: {
                             options: filteredVars,
-                            allowUnselect: !((_a2 = v.metadata) == null ? void 0 : _a2.isReadonly)
+                            allowUnselect: !((_a2 = v.metadata) == null ? void 0 : _a2.isReadOnly)
                           }
                         },
                         right: {

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -3061,7 +3061,6 @@ var Ticket = class {
                   label: "Select board*",
                   placeholder: "Select a board",
                   isSearchable: true,
-                  allowUnselect: true,
                   options: (cbk) => __async(this, null, function* () {
                     const response = yield cbk.api.get("/ticketing/boards");
                     return (response == null ? void 0 : response.result) ? response.result.map(
@@ -3099,7 +3098,6 @@ var Ticket = class {
                 componentProps: {
                   label: "Function",
                   placeholder: "Select a function",
-                  allowUnselect: true,
                   options: [
                     {
                       label: "Create new ticket",
@@ -3121,7 +3119,6 @@ var Ticket = class {
                   label: "Ticket layout",
                   placeholder: "Select ticket layout",
                   isSearchable: true,
-                  allowUnselect: true,
                   options: (cbk) => __async(this, null, function* () {
                     var _a, _b;
                     const response = yield cbk.api.get(
@@ -3227,8 +3224,7 @@ var Ticket = class {
                 componentProps: {
                   label: "Add subject into a ticket*",
                   placeholder: "--None--",
-                  options: "getTicketingEmailSubjectVariables",
-                  allowUnselect: true
+                  options: "getTicketingEmailSubjectVariables"
                 },
                 validators: [
                   {
@@ -3254,8 +3250,7 @@ var Ticket = class {
                 componentProps: {
                   label: "Add messages into ticket's conversation thread",
                   placeholder: "--None--",
-                  options: "getTextVariables",
-                  allowUnselect: true
+                  options: "getTextVariables"
                 }
               }
             ]

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -3285,7 +3285,8 @@ var Ticket = class {
             ref: "ticket_return_id",
             component: "TextInput",
             componentProps: {
-              label: "Return ID"
+              label: "Return ID",
+              showPageRef: true
             },
             validators: [
               {


### PR DESCRIPTION
- Fix field still showing "--None--" for read only field: change `isReadonly` to `isReadOnly`
- Remove allowUnselect for all fields except keyvalue mapping
- Added showPageRef prop, to be used by TextInput field to show pageRef as default value (eg. Return Id field of ticketing block should by default show its pageRef, TICKET2 etc)