### PR TITLE
Feature/add base to export

### DIFF
--- a/.changeset/three-news-mate.md
+++ b/.changeset/three-news-mate.md
@@ -1,0 +1,5 @@
+---
+"custom-block-kit": minor
+---
+
+add base.ts to build export

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -157,4 +157,4 @@ declare class Ticket {
     schema: BaseSchema;
 }
 
-export { DateCalc, SetVariable, Sharepoint, Ticket, Triage };
+export { BackendCBK, BaseSchema, ComponentOptionProps, ComponentProps, DateCalc, Editor, EditorField, FrontendCBK, KeyValueOptionProp, OptionState, OutputProps, SetVariable, Sharepoint, Stencil, StudioShape, Ticket, Triage, ValidatorProps };

--- a/index.ts
+++ b/index.ts
@@ -1,1 +1,2 @@
 export * from "./blocks";
+export * from "./base";


### PR DESCRIPTION
Added the base file to export to allow for all types to be export accordingly. Within our frontend we are incorrectly referencing these types by going `import type x from 'custom-block-kit/base'` which reference the ts file not the actually exported module. 

example: 
SelectInput.tsx: 
![image](https://github.com/CheckboxAI/custom-block-kit/assets/9062257/64ddf1af-617d-457d-b5db-22905e8cdb61)

