### PR TITLE
DEV-14503: Fix ticket block empty or optional doc variable

### DIFF
--- a/.changeset/hip-suits-learn.md
+++ b/.changeset/hip-suits-learn.md
@@ -1,0 +1,5 @@
+---
+"custom-block-kit": patch
+---
+
+DEV-14503: Fix ticket block empty or optional doc variable

--- a/blocks/ticket/ticket.ts
+++ b/blocks/ticket/ticket.ts
@@ -353,9 +353,9 @@ export class Ticket {
           let attachmentPayload = [];
           for (const attachmentVar of attachmentVariables) {
             const uploadedFiles = JSON.parse(
-              cbk.getVariable(attachmentVar.variable) ?? "[]"
+              tryGetVariable(cbk, attachmentVar.variable) ?? "[]"
             );
-            // when docx file is uploaded, a pdf version is also generated and returned. 
+            // when docx file is uploaded, a pdf version is also generated and returned.
             // Both will have same documentId, so we filter out the pdf version here
             const filteredFiles = uploadedFiles.filter(
               (item: any, _: any, allFiles: any) =>

--- a/dist/index.js
+++ b/dist/index.js
@@ -3466,7 +3466,7 @@ var Ticket = class {
             let attachmentPayload = [];
             for (const attachmentVar of attachmentVariables) {
               const uploadedFiles = JSON.parse(
-                (_c = cbk.getVariable(attachmentVar.variable)) != null ? _c : "[]"
+                (_c = tryGetVariable(cbk, attachmentVar.variable)) != null ? _c : "[]"
               );
               const filteredFiles = uploadedFiles.filter(
                 (item, _, allFiles) => !(item.fileName.endsWith(".pdf") && allFiles.some(

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -3437,7 +3437,7 @@ var Ticket = class {
             let attachmentPayload = [];
             for (const attachmentVar of attachmentVariables) {
               const uploadedFiles = JSON.parse(
-                (_c = cbk.getVariable(attachmentVar.variable)) != null ? _c : "[]"
+                (_c = tryGetVariable(cbk, attachmentVar.variable)) != null ? _c : "[]"
               );
               const filteredFiles = uploadedFiles.filter(
                 (item, _, allFiles) => !(item.fileName.endsWith(".pdf") && allFiles.some(


### PR DESCRIPTION
The previous [fix](https://github.com/Checkbox-Technology-Pty-Ltd/cbdev/pull/337/files) introduce some bug in the javascript block causing assessment to be blocked at the moment. Refer [here](https://checkboxai.atlassian.net/browse/DEV-14503?focusedCommentId=37527).

Instead of updating bejavascript code, will isolate this fix to ticket block only and make use of the existing `tryGetVariable` which already handle the error thrown from bejavascript code

Recording: https://jam.dev/c/545be883-f754-4ebc-9aa4-e5c4f5a58af9