### PR TITLE
DEV-14546: Hide Duration field from create matter section in ticketing block

### DIFF
--- a/.changeset/mean-kiwis-punch.md
+++ b/.changeset/mean-kiwis-punch.md
@@ -1,0 +1,5 @@
+---
+"custom-block-kit": patch
+---
+
+Hide Duration field from create matter fields in ticketing block

--- a/blocks/ticket/ticket.ts
+++ b/blocks/ticket/ticket.ts
@@ -158,41 +158,43 @@ export class Ticket {
                     };
 
                   return response
-                    ? response?.result?.fields?.map((v: any) => {
-                        const mapping =
-                          ticketingWorkflowVarMapping[v.fieldType];
+                    ? response?.result?.fields
+                        ?.filter((v: any) => v.fieldType !== "DURATION") // hide duration field
+                        .map((v: any) => {
+                          const mapping =
+                            ticketingWorkflowVarMapping[v.fieldType];
 
-                        let filteredVars = allWorkflowVars.filter(
-                          (workflowVar) =>
-                            !mapping ||
-                            mapping?.includes(workflowVar.type) ||
-                            // for single select and status field, we allow COMP variable
-                            ((v.fieldType === "SEL" ||
-                              v.fieldType === "STATUS") &&
-                              /^COMP\d+/.test(workflowVar.label))
-                        );
+                          let filteredVars = allWorkflowVars.filter(
+                            (workflowVar) =>
+                              !mapping ||
+                              mapping?.includes(workflowVar.type) ||
+                              // for single select and status field, we allow COMP variable
+                              ((v.fieldType === "SEL" ||
+                                v.fieldType === "STATUS") &&
+                                /^COMP\d+/.test(workflowVar.label))
+                          );
 
-                        return {
-                          left: {
-                            ref: "value",
-                            component: "SelectInput",
-                            componentProps: {
-                              options: filteredVars,
-                              allowUnselect: !v.metadata?.isReadOnly,
+                          return {
+                            left: {
+                              ref: "value",
+                              component: "SelectInput",
+                              componentProps: {
+                                options: filteredVars,
+                                allowUnselect: !v.metadata?.isReadOnly,
+                              },
                             },
-                          },
-                          right: {
-                            ref: "id",
-                            component: "TextValueDisplay",
-                            componentProps: {
-                              readOnly: true,
-                              value: v.id,
-                              displayText: v.name,
-                              type: v.fieldType,
+                            right: {
+                              ref: "id",
+                              component: "TextValueDisplay",
+                              componentProps: {
+                                readOnly: true,
+                                value: v.id,
+                                displayText: v.name,
+                                type: v.fieldType,
+                              },
                             },
-                          },
-                        } as KeyValueOptionProp;
-                      })
+                          } as KeyValueOptionProp;
+                        })
                     : [];
                 },
               },

--- a/dist/index.js
+++ b/dist/index.js
@@ -3288,7 +3288,7 @@ var Ticket = class {
                       DATE_TIME: ["DATE"],
                       STATUS: ["TXT", "SEL", "RAD", "CBX", "ACT"]
                     };
-                    return response ? (_b = (_a = response == null ? void 0 : response.result) == null ? void 0 : _a.fields) == null ? void 0 : _b.map((v) => {
+                    return response ? (_b = (_a = response == null ? void 0 : response.result) == null ? void 0 : _a.fields) == null ? void 0 : _b.filter((v) => v.fieldType !== "DURATION").map((v) => {
                       var _a2;
                       const mapping = ticketingWorkflowVarMapping[v.fieldType];
                       let filteredVars = allWorkflowVars.filter(

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -3259,7 +3259,7 @@ var Ticket = class {
                       DATE_TIME: ["DATE"],
                       STATUS: ["TXT", "SEL", "RAD", "CBX", "ACT"]
                     };
-                    return response ? (_b = (_a = response == null ? void 0 : response.result) == null ? void 0 : _a.fields) == null ? void 0 : _b.map((v) => {
+                    return response ? (_b = (_a = response == null ? void 0 : response.result) == null ? void 0 : _a.fields) == null ? void 0 : _b.filter((v) => v.fieldType !== "DURATION").map((v) => {
                       var _a2;
                       const mapping = ticketingWorkflowVarMapping[v.fieldType];
                       let filteredVars = allWorkflowVars.filter(


### PR DESCRIPTION
Jira: https://checkboxai.atlassian.net/browse/DEV-14546

We need to hide the Duration field from ticketing block since it's a read-only field. 

|Matter layout (has Duration fields)|Ticketing block (Duration field hidden)| 
|------|------|
|<img width="668" alt="Screenshot 2025-01-10 at 3 39 30 PM" src="https://github.com/user-attachments/assets/e3f1cfbd-e183-4e9b-a43f-ae8ebdc7f3b9" />|<img width="458" alt="Screenshot 2025-01-10 at 3 39 12 PM" src="https://github.com/user-attachments/assets/f7651ecb-3ae7-4e48-a600-193d1f1e6eb9" />|

