### PR TITLE
DEV-15639 Filter files based on upload context before submission

### DIFF
--- a/blocks/ticket/ticket.ts
+++ b/blocks/ticket/ticket.ts
@@ -1,5 +1,5 @@
 import type { BaseSchema, KeyValueOptionProp } from "../../base/base";
-import { FileMetadata } from "./types";
+import type { FileMetadata } from "./types";
 import { tryGetVariable } from "./utils";
 
 export class Ticket {

--- a/blocks/ticket/types.d.ts
+++ b/blocks/ticket/types.d.ts
@@ -1,1 +1,11 @@
-export type Option = { label: string; value: string };
+export type FileMetadata = {
+    fileKey: string;
+    fileName: string;
+    publicKey: string;
+    // below are optional, not present in file input uploads
+    reportName?: string;
+    fileType?: string;
+    documentId?: string;
+    documentVersionId?: string;
+    originalFile?: boolean;
+};

--- a/dist/index.js
+++ b/dist/index.js
@@ -3431,6 +3431,16 @@ var Ticket = class {
         try {
           const fn = cbk.getElementValue("fn_selector");
           if (fn === "create_new_ticket") {
+            let filterFiles2 = function(files) {
+              if (!Array.isArray(files))
+                return [];
+              const hasOriginalTrue = files.some((f) => f.originalFile === true);
+              if (hasOriginalTrue) {
+                return files.filter((f) => f.originalFile === true);
+              }
+              return files;
+            };
+            var filterFiles = filterFiles2;
             const boardId = cbk.getElementValue("board_id");
             const ticketLayoutId = cbk.getElementValue("ticket_layout_id");
             const subjectVariable = cbk.getElementValue("subject_variable");
@@ -3468,9 +3478,7 @@ var Ticket = class {
               const uploadedFiles = JSON.parse(
                 (_c = tryGetVariable(cbk, attachmentVar.variable)) != null ? _c : "[]"
               );
-              const filteredFiles = uploadedFiles.filter(
-                (item) => item.originalFile || !("originalFile" in item)
-              );
+              const filteredFiles = filterFiles2(uploadedFiles);
               for (const uploadedFile of filteredFiles) {
                 attachmentPayload.push({
                   fileName: uploadedFile.fileName,

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -3402,6 +3402,16 @@ var Ticket = class {
         try {
           const fn = cbk.getElementValue("fn_selector");
           if (fn === "create_new_ticket") {
+            let filterFiles2 = function(files) {
+              if (!Array.isArray(files))
+                return [];
+              const hasOriginalTrue = files.some((f) => f.originalFile === true);
+              if (hasOriginalTrue) {
+                return files.filter((f) => f.originalFile === true);
+              }
+              return files;
+            };
+            var filterFiles = filterFiles2;
             const boardId = cbk.getElementValue("board_id");
             const ticketLayoutId = cbk.getElementValue("ticket_layout_id");
             const subjectVariable = cbk.getElementValue("subject_variable");
@@ -3439,9 +3449,7 @@ var Ticket = class {
               const uploadedFiles = JSON.parse(
                 (_c = tryGetVariable(cbk, attachmentVar.variable)) != null ? _c : "[]"
               );
-              const filteredFiles = uploadedFiles.filter(
-                (item) => item.originalFile || !("originalFile" in item)
-              );
+              const filteredFiles = filterFiles2(uploadedFiles);
               for (const uploadedFile of filteredFiles) {
                 attachmentPayload.push({
                   fileName: uploadedFile.fileName,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "custom-block-kit",
-    "version": "1.10.2",
+    "version": "1.10.9",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "custom-block-kit",
-            "version": "1.10.2",
+            "version": "1.10.9",
             "license": "ISC",
             "dependencies": {
                 "@microsoft/microsoft-graph-client": "^3.0.5",


### PR DESCRIPTION
Handle file filtering for Ticketing Block submission

#### Summary

This PR adds logic to filter files before submitting to the ticketing block. Since the ticketing block currently only supports accepting **one source of files** (either user-uploaded or system-generated), this logic ensures we only keep the relevant ones.

#### Context

When a user uploads documents via input blocks, or when files are generated by system (e.g., from Doc Gen block), we may receive multiple file entries. We want to:

* Prevent duplicated file types (like a `.docx` and a system-generated `.pdf`) from user upload
* Preserve intentional user or system-generated files depending on context

#### Testing

Manual & locally: https://jam.dev/c/5cde8d8c-d952-48a4-ab3d-5c4dd2002d01

#### Received Data Examples

```js
// User upload Docx via Doc input field: we will receive two files (one original + one generated PDF)
 [
  {
    reportName: 'docx-111kB.docx',
    fileName: 'docx-111kB.docx',
    fileKey: '13adbbef-c975-41d5-9b88-bcb59a21e7bb',
    publicKey: '492cf737-3087-4706-8697-7f44d18e12ce',
    fileType: 'report',
    documentId: 'e870a1ce-199b-4ae8-8461-374dce262439',
    documentVersionId: '50a8f67e-eaa7-4624-8012-f820a88d8eaf',
    originalFile: true
  },
  {
    reportName: 'docx-111kB.docx',
    fileName: 'docx-111kB.pdf',
    fileKey: '4c1c9c5b-c02e-4af1-afb4-24e6a77d5d4f',
    publicKey: 'c08de168-023b-4cd1-9534-8c2b6a6b8a50',
    fileType: 'report',
    documentId: 'e870a1ce-199b-4ae8-8461-374dce262439',
    documentVersionId: '50a8f67e-eaa7-4624-8012-f820a88d8eaf',
    originalFile: false
  }
]
// User upload PDF via Doc input field: we will receive two files
 [
  {
    reportName: 'pdf-143kB.pdf',
    fileName: 'pdf-143kB.docx',
    fileKey: '555cb9fe-bdf3-4f56-a6bc-581198d803b3',
    publicKey: '2c063f75-8510-4708-b1d4-269521e0d6e4',
    fileType: 'report',
    documentId: 'dbed6f8f-3b29-420b-aaa2-7d441424779f',
    documentVersionId: '550a0c9c-4f5b-4c12-b555-82238226b7e4',
    originalFile: false
  },
  {
    reportName: 'pdf-143kB.pdf',
    fileName: 'pdf-143kB.pdf',
    fileKey: '555cb9fe-bdf3-4f56-a6bc-581198d803b3',
    publicKey: '2c063f75-8510-4708-b1d4-269521e0d6e4',
    fileType: 'report',
    documentId: 'dbed6f8f-3b29-420b-aaa2-7d441424779f',
    documentVersionId: '550a0c9c-4f5b-4c12-b555-82238226b7e4',
    originalFile: true
  }
]
// User upload Docx via file input field: we will receive one file
[
  {
    fileKey: 'a9ab887e-5f29-46ec-961a-174c4dc190d4',
    fileName: 'docx-111kB.docx',
    publicKey: '03ca49d9-8d0f-4c36-a95a-e2683f21c346'
  }
]
// User uploads PDF via file input field: we will receive one file
[
  {
    fileKey: '1dc25f69-9496-490b-be2a-26d6faf3fcf8',
    fileName: 'pdf-143kB.pdf',
    publicKey: 'caf8d5f2-065c-4844-82ac-d4f6b38a192f'
  }
]
// Doc Gen block generates two files (Docx and PDF), regardless what the studio configuration is
[
  {
    reportName: 'Document',
    fileName: 'Document.docx',
    fileKey: 'ece315cc-6611-432f-a029-705d897ba68b',
    publicKey: '3dfd1df0-a2ab-4d0b-b3b3-596511cb0c37',
    fileType: 'report',
    documentId: 'ac643981-4d10-4cea-92c8-d291d7fa11fb',
    documentVersionId: '127eac1b-db88-4eda-882d-3417e589f94c',
    originalFile: false
  },
  {
    reportName: 'Document',
    fileName: 'Document.pdf',
    fileKey: '6fad4c68-f656-4fda-a68b-55b63dd1679c',
    publicKey: '361ebc0d-b5f4-4884-aeec-0d4d3d569e4b',
    fileType: 'report',
    documentId: 'ac643981-4d10-4cea-92c8-d291d7fa11fb',
    documentVersionId: '127eac1b-db88-4eda-882d-3417e589f94c',
    originalFile: false
  }
]
```

#### References

Previous changes were made in: [https://github.com/CheckboxAI/custom-block-kit/pull/193](https://github.com/CheckboxAI/custom-block-kit/pull/193)
