### PR TITLE
DEV-15718 Process only Docx file for Doc Gen block

### DIFF
--- a/.changeset/six-moose-tan.md
+++ b/.changeset/six-moose-tan.md
@@ -1,0 +1,5 @@
+---
+"custom-block-kit": patch
+---
+
+Process only Docx file for Doc Gen block

--- a/dist/index.js
+++ b/dist/index.js
@@ -3434,11 +3434,18 @@ var Ticket = class {
             let filterFiles2 = function(files) {
               if (!Array.isArray(files))
                 return [];
-              const hasOriginalTrue = files.some((f) => f.originalFile === true);
-              if (hasOriginalTrue) {
-                return files.filter((f) => f.originalFile === true);
-              }
-              return files;
+              return files.reduce((acc, item) => {
+                if (!("originalFile" in item)) {
+                  return acc.concat(item);
+                }
+                if (item.originalFile === true) {
+                  return acc.concat(item);
+                }
+                if (item.fileName.toLowerCase().endsWith(".docx")) {
+                  return acc.concat(item);
+                }
+                return acc;
+              }, []);
             };
             var filterFiles = filterFiles2;
             const boardId = cbk.getElementValue("board_id");

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -3405,11 +3405,18 @@ var Ticket = class {
             let filterFiles2 = function(files) {
               if (!Array.isArray(files))
                 return [];
-              const hasOriginalTrue = files.some((f) => f.originalFile === true);
-              if (hasOriginalTrue) {
-                return files.filter((f) => f.originalFile === true);
-              }
-              return files;
+              return files.reduce((acc, item) => {
+                if (!("originalFile" in item)) {
+                  return acc.concat(item);
+                }
+                if (item.originalFile === true) {
+                  return acc.concat(item);
+                }
+                if (item.fileName.toLowerCase().endsWith(".docx")) {
+                  return acc.concat(item);
+                }
+                return acc;
+              }, []);
             };
             var filterFiles = filterFiles2;
             const boardId = cbk.getElementValue("board_id");


### PR DESCRIPTION
Test cases and recording:

1. user upload single file via doc upload component - should display only that file in the matter
https://jam.dev/c/ac652d68-56c0-4186-b97f-2b738a69b075
2. user upload single file via file upload component - should display only that file in the matter
https://jam.dev/c/f7145c9c-a689-400b-b4d9-76b826bb1c8f
3. workflow include single doc gen - should only have 1 docx file
https://jam.dev/c/a26bbf50-098e-4c20-9d98-f8efd521a36e
4. workflow include multiple doc gen - should have 3 docx files
https://jam.dev/c/26af2ddb-0d26-4a18-99d1-7e10825228fd
5. user upload multiple files + multiple doc gen - should have user uploaded files + 3 doc gen's docx files
https://jam.dev/c/36bb198a-e503-4519-902d-da73f21e5727